### PR TITLE
docs: define minimal notebook and note convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,22 @@ La nota metodologica completa del benchmark e' in:
 
 Il notebook principale puo' leggere un CSV bundled molto piccolo in `data/`,
 cosi' resta leggibile e riusabile anche fuori dal workspace del Lab.
+
+## Convenzione minima
+
+La repo resta volutamente leggera.
+
+- notebook: un notebook per caso o domanda, con nome descrittivo e specifico
+- note: note brevi su domanda guida, fonte, caveat e perimetro
+- usare solo notebook quando basta una lettura esplorativa con codice e grafici
+- usare notebook + nota quando il filone ha gia' un piccolo risultato leggibile
+- evitare naming rigidi o tassonomie pesanti finche' la repo resta piccola
+
+## Dati bundled
+
+Alcuni notebook leggono CSV piccoli versionati in `data/`.
+
+- servono a rendere i notebook piu' leggeri e riproducibili
+- sono sottoinsiemi minimi estratti da fonti o output piu' ricchi
+- non sostituiscono la fonte primaria
+- quando il dato deriva dal Lab, la provenance va esplicitata nella nota del caso

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -7,6 +7,7 @@ Regola pratica:
 - un notebook per caso o domanda
 - titolo leggibile e specifico
 - niente logica di progetto troppo pesante finche' il filone resta esplorativo
+- naming descrittivo, senza numerazioni forzate o prefissi rigidi
 
 Pattern consigliato:
 
@@ -14,3 +15,5 @@ Pattern consigliato:
 - i grafici vengono esportati in `figures/`
 - `README` e note rimandano ai PNG esportati
 - il notebook resta eseguito e leggibile anche su GitHub
+- se il notebook produce un risultato gia' presentabile, conviene affiancarlo
+  a una nota breve in `notes/`

--- a/notes/README.md
+++ b/notes/README.md
@@ -6,5 +6,12 @@ Qui stanno note brevi di contesto:
 - fonte pubblica
 - caveat
 - decisioni locali sul perimetro
+- provenance del dato bundled, se il notebook usa un CSV minimo in `data/`
+
+Regola pratica:
+
+- una nota basta quando serve soprattutto contesto o sintesi
+- notebook + nota e' il formato giusto quando un filone ha gia' numeri e grafici
+- naming descrittivo e vicino al tema, senza convenzioni rigide inutili
 
 Se una nota diventa pubblica o strutturale, non deve restare solo qui.


### PR DESCRIPTION
## Contesto
Chiude `#4` senza introdurre una policy pesante.

## Cosa cambia
- aggiunge nel `README` una convenzione minima per notebook e note
- chiarisce nel `README` il ruolo dei CSV bundled in `data/`
- aggiorna `notebooks/README.md` e `notes/README.md` con regole pratiche coerenti col formato attuale della repo

## Taglio
- niente naming rigido o numerazioni forzate
- notebook per caso/domanda
- nota breve quando serve contesto, caveat o provenance
- notebook + nota quando il filone ha gia' un risultato leggibile

Closes #4
