### PR TITLE
docs: clarify Lab provenance in notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ Alcuni notebook leggono CSV piccoli versionati in `data/`.
 - servono a rendere i notebook piu' leggeri e riproducibili
 - sono sottoinsiemi minimi estratti da fonti o output piu' ricchi
 - non sostituiscono la fonte primaria
-- quando il dato deriva dal Lab, la provenance va esplicitata nella nota del caso
+- quando il dato deriva dal Lab, di solito basta una riga esplicita nella nota
+  del caso su origine del CSV bundled e filone o repo di provenienza
 
 ## Confine con il Lab
 

--- a/notes/abbiategrasso-finanza-comunale-minimale.md
+++ b/notes/abbiategrasso-finanza-comunale-minimale.md
@@ -11,7 +11,7 @@ risorse esterne nel confronto con alcuni comuni gia' usati nei filoni locali?
 ## Fonte
 
 - base bundled nella repo: `data/abbiategrasso_finanza_minimale_2021_2025.csv`
-- origine del dato: `siope-comuni/entrate/comuni`
+- origine del dato: [`siope-comuni/entrate/comuni`](https://github.com/dataciviclab/siope-comuni/tree/main/entrate/comuni)
 - fonte pubblica primaria: SIOPE
 
 Il CSV bundled deriva dal mart multi-anno del Lab e mantiene solo un perimetro

--- a/notes/abbiategrasso-irpef-comunale.md
+++ b/notes/abbiategrasso-irpef-comunale.md
@@ -11,8 +11,11 @@ benchmark territoriale?
 ## Fonte
 
 - base bundled nella repo: `data/abbiategrasso_irpef_benchmark_2019_2023.csv`
-- origine del dato: `dataciviclab/preanalysis/irpef-comunale-2019-2023`
+- origine del dato: [`dataciviclab/preanalysis/irpef-comunale-2019-2023`](https://github.com/dataciviclab/dataciviclab/tree/main/preanalysis/irpef-comunale-2019-2023)
 - fonte pubblica primaria: MEF / Finanze, dati comunali IRPEF
+
+Il CSV bundled e' un estratto minimo derivato dal lavoro gia' fatto nel Lab e
+serve solo a rendere questo notebook locale leggero e riproducibile.
 
 ## Perimetro minimo
 

--- a/notes/abbiategrasso-irpef-sud-ovest-milanese.md
+++ b/notes/abbiategrasso-irpef-sud-ovest-milanese.md
@@ -10,8 +10,11 @@ perimetro piu' stretto del Sud Ovest milanese?
 ## Fonte
 
 - base bundled: `data/abbiategrasso_irpef_sud_ovest_2019_2023.csv`
-- origine del dato: `dataciviclab/preanalysis/irpef-comunale-2019-2023`
+- origine del dato: [`dataciviclab/preanalysis/irpef-comunale-2019-2023`](https://github.com/dataciviclab/dataciviclab/tree/main/preanalysis/irpef-comunale-2019-2023)
 - fonte pubblica primaria: MEF / Finanze, dati comunali IRPEF
+
+Anche qui il CSV bundled e' un estratto minimo derivato dal filone Lab gia'
+esistente, adattato a un confronto locale piu' stretto.
 
 ## Perimetro
 

--- a/notes/abbiategrasso-popolazione-consumo-suolo.md
+++ b/notes/abbiategrasso-popolazione-consumo-suolo.md
@@ -14,6 +14,8 @@ Che fotografia minima possiamo ottenere su Abbiategrasso incrociando:
 - candidate `ispra-consumo-suolo`
 
 Entrambe le fonti sono gia' materializzate in `dataset-incubator/out/`.
+Il notebook locale usa un estratto minimo derivato da questi output del
+workspace Lab, non una nuova pipeline dentro questa repo.
 
 ## Snapshot iniziale
 


### PR DESCRIPTION
## Cosa cambia

Aggiunge provenance esplicita nelle note dei casi che usano CSV bundled derivati dal Lab.

- `notes/abbiategrasso-irpef-comunale.md`: link a `dataciviclab/preanalysis/irpef-comunale-2019-2023` + riga che chiarisce il CSV come estratto minimo del lavoro Lab
- `notes/abbiategrasso-irpef-sud-ovest-milanese.md`: stesso pattern
- `notes/abbiategrasso-popolazione-consumo-suolo.md`: riga che chiarisce l'uso di output del workspace, non una nuova pipeline
- `notes/abbiategrasso-finanza-comunale-minimale.md`: link cliccabile a `siope-comuni/entrate/comuni`
- `README.md`: regola sui dati bundled resa più concreta

## Tipo

docs-only — nessun cambio a notebook, dati o script.