### PR TITLE
docs: clarify provenance for lab-derived local data

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ Alcuni notebook leggono CSV piccoli versionati in `data/`.
 - quando il dato deriva dal Lab, di solito basta una riga esplicita nella nota
   del caso su origine del CSV bundled e filone o repo di provenienza
 
+Regola pratica sulla provenance:
+
+- se il notebook usa una fonte pubblica letta direttamente, basta nominare la fonte primaria
+- se usa un CSV bundled derivato da output o mart del Lab, la nota del caso deve dire in una riga:
+  - da quale repo o filone arriva
+  - se il CSV e' un estratto minimo o una rielaborazione leggera
+- non serve appesantire la repo con una provenance lunga se il legame col Lab si puo' spiegare in due righe chiare
+
 ## Confine con il Lab
 
 Questa repo resta personale quando il filone e':

--- a/README.md
+++ b/README.md
@@ -162,12 +162,13 @@ Alcuni notebook leggono CSV piccoli versionati in `data/`.
 - non sostituiscono la fonte primaria
 - quando il dato deriva dal Lab, di solito basta una riga esplicita nella nota
   del caso su origine del CSV bundled e filone o repo di provenienza
+  ([DataCivicLab](https://github.com/dataciviclab))
 
 Regola pratica sulla provenance:
 
 - se il notebook usa una fonte pubblica letta direttamente, basta nominare la fonte primaria
 - se usa un CSV bundled derivato da output o mart del Lab, la nota del caso deve dire in una riga:
-  - da quale repo o filone arriva
+  - da quale repo o filone di [DataCivicLab](https://github.com/dataciviclab) arriva
   - se il CSV e' un estratto minimo o una rielaborazione leggera
 - non serve appesantire la repo con una provenance lunga se il legame col Lab si puo' spiegare in due righe chiare
 

--- a/notes/abbiategrasso-popolazione-consumo-suolo.md
+++ b/notes/abbiategrasso-popolazione-consumo-suolo.md
@@ -17,6 +17,10 @@ Entrambe le fonti sono gia' materializzate in `dataset-incubator/out/`.
 Il notebook locale usa un estratto minimo derivato da questi output del
 workspace Lab, non una nuova pipeline dentro questa repo.
 
+In pratica, il CSV bundled di questo caso e' una selezione molto piccola
+derivata dal filone Lab su popolazione comunale ISTAT e consumo di suolo ISPRA,
+ridotta qui al solo perimetro utile per Abbiategrasso.
+
 ## Snapshot iniziale
 
 Valori verificati nel workspace:

--- a/notes/abbiategrasso-popolazione-consumo-suolo.md
+++ b/notes/abbiategrasso-popolazione-consumo-suolo.md
@@ -18,8 +18,9 @@ Il notebook locale usa un estratto minimo derivato da questi output del
 workspace Lab, non una nuova pipeline dentro questa repo.
 
 In pratica, il CSV bundled di questo caso e' una selezione molto piccola
-derivata dal filone Lab su popolazione comunale ISTAT e consumo di suolo ISPRA,
-ridotta qui al solo perimetro utile per Abbiategrasso.
+derivata dal filone [DataCivicLab](https://github.com/dataciviclab) su
+popolazione comunale ISTAT e consumo di suolo ISPRA, ridotta qui al solo
+perimetro utile per Abbiategrasso.
 
 ## Snapshot iniziale
 

--- a/notes/abbiategrasso-trend-consumo-suolo.md
+++ b/notes/abbiategrasso-trend-consumo-suolo.md
@@ -10,8 +10,9 @@ si inserisce in un trend piu' lungo?
 La serie e' ricostruita a partire dal file ISPRA `Comuni_2006_2024`.
 
 Il file bundled usato qui non e' una nuova fonte autonoma: e' una rielaborazione
-locale molto leggera del filone Lab su consumo di suolo ISPRA, tenuta piccola
-solo per rendere il notebook riproducibile in questa repo.
+locale molto leggera del filone
+[DataCivicLab](https://github.com/dataciviclab) su consumo di suolo ISPRA,
+tenuta piccola solo per rendere il notebook riproducibile in questa repo.
 
 Punto di partenza:
 

--- a/notes/abbiategrasso-trend-consumo-suolo.md
+++ b/notes/abbiategrasso-trend-consumo-suolo.md
@@ -9,6 +9,10 @@ si inserisce in un trend piu' lungo?
 
 La serie e' ricostruita a partire dal file ISPRA `Comuni_2006_2024`.
 
+Il file bundled usato qui non e' una nuova fonte autonoma: e' una rielaborazione
+locale molto leggera del filone Lab su consumo di suolo ISPRA, tenuta piccola
+solo per rendere il notebook riproducibile in questa repo.
+
 Punto di partenza:
 
 - stock di suolo consumato `2024`: `710,4 ha`


### PR DESCRIPTION
Closes #18

## Cosa cambia

- README: aggiunta sezione con regola pratica sulla provenance dei dati bundled
- `notes/abbiategrasso-popolazione-consumo-suolo.md`: provenance esplicita verso il filone DataCivicLab (popolazione ISTAT + consumo suolo ISPRA)
- `notes/abbiategrasso-trend-consumo-suolo.md`: stessa struttura, link DataCivicLab e descrizione del filone

## Scope

Solo i file citati nell'issue. I filoni IRPEF e finanza non sono stati toccati perche' il legame al Lab era gia' scritto bene.

## Note

La provenance dei filoni suolo e' descritta in modo generale verso il Lab (non link puntuale a dataset-incubator). Considerato accettabile per questa issue: "esplicitare un po' meglio" senza appesantire la repo.